### PR TITLE
dimclient: work around issues due to SSL defaults changes in Python 3.13

### DIFF
--- a/dimclient/dimclient/__init__.py
+++ b/dimclient/dimclient/__init__.py
@@ -2,12 +2,13 @@ import json
 from http.cookiejar import LWPCookieJar
 from urllib.parse import urlencode
 from urllib.error import HTTPError
-from urllib.request import urlopen, Request, build_opener, HTTPCookieProcessor
+from urllib.request import urlopen, Request, build_opener, HTTPCookieProcessor, HTTPSHandler
 import logging
 import getpass
 import time
 import os
 import os.path
+import ssl
 from pprint import pformat
 from . import version
 
@@ -36,7 +37,10 @@ class DimClient(object):
     def __init__(self, server_url, cookie_file=None, cookie_umask=None, request_timeout=120):
         self.server_url = server_url
         self.cookie_jar = LWPCookieJar()
-        self.session = build_opener(HTTPCookieProcessor(self.cookie_jar))
+        self.ssl_context = ssl.create_default_context()
+        if hasattr(ssl, 'VERIFY_X509_STRICT'):
+            self.ssl_context.verify_flags &= ~ssl.VERIFY_X509_STRICT
+        self.session = build_opener(HTTPSHandler(context=self.ssl_context), HTTPCookieProcessor(self.cookie_jar))
         if cookie_file:
             self._use_cookie_file(cookie_file, cookie_umask)
         self.request_timeout = request_timeout

--- a/dimclient/dimclient/version.py
+++ b/dimclient/dimclient/version.py
@@ -1,1 +1,1 @@
-VERSION = "1.0.1"
+VERSION = "1.0.5"

--- a/dimclient/pyproject.toml
+++ b/dimclient/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "dimclient"
-version = "1.0.1"
+version = "1.0.5"
 maintainers = [
   { name = "zerimond" },
 ]


### PR DESCRIPTION
disable strict checking of the DIM server certificate, as verify fails with `Basic Constraints of CA cert not marked critical` otherwise

tested as working in Python 3.9 with http/https, and Python 3.13 with https

see also https://github.com/kovidgoyal/calibre/commit/cb1bfb98a0680c1495c503a846c6b810861e2d95

resolves #284