### PR TITLE
fix(dim/ndcli): issue of adding TXT records fixed on importing zone.

### DIFF
--- a/ndcli/dimcli/zoneimport.py
+++ b/ndcli/dimcli/zoneimport.py
@@ -22,8 +22,8 @@ rdata_params = {
     'CNAME': lambda rdata: dict(cname=str(rdata.target)),
     'MX': lambda rdata: dict(preference=int(rdata.preference), exchange=str(rdata.exchange)),
     'NS': lambda rdata: dict(nsdname=str(rdata.target)),
-    'TXT': lambda rdata: dict(strings=rdata.strings),
-    'SPF': lambda rdata: dict(strings=rdata.strings),
+    'TXT': lambda rdata: dict(strings=rdata.to_text()),
+    'SPF': lambda rdata: dict(strings=rdata.to_text()),
     'RP': lambda rdata: dict(mbox=str(rdata.mbox), txtdname=str(rdata.txt)),
     'HINFO': lambda rdata: dict(cpu=rdata.cpu, os=rdata.os),
     'SRV': lambda rdata:


### PR DESCRIPTION
The problem of following cases on importing a new zone solved.

Before patch:
```
$ cat <<EOF | ndcli import zone dlan.legacy.test
; <<>> DiG 9.8.2rc1-RedHat-9.8.2-0.10.rc1.el6_3.6 <<>> axfr dlan.legacy.test @anyins-ins-bs01.dlan.legacy.test
;; global options: +cmd
dlan.legacy.test.        3600    IN      SOA     ins01.internal.test. dnsadmin.company.com. 2005110840 600 180 604800 3600
dlan.legacy.test.        3600    IN      NS      ins01.internal.test.
dlan.legacy.test.        3600    IN      NS      ins02.internal.test.
1021931729._dkimkey.dlan.legacy.test. 300 IN TXT "v=DKIM1\;k=rsa\;p=MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQCFpZEaLQAbzDDMkmDMZNzulKNI9QWcGOtD9SaMPwJ48xHRfTUxW1AIUgH/i1gFg0uM988hcNSyljkK81p0ASDGTmRBEwDZrHE+G96XOUhi4OZppteMswbbuDy3AIXQB/JG5ktFl0eYdAejkucOG0uIlvpeNhrSNn2wjASgYlqJBwIDAQAB"
1021931729._domainkey.dlan.legacy.test. 300 IN TXT "v=DKIM1\;k=rsa\;p=MFwwDQYJKoZIhvcNAQEBBQADSwAwSAJBAKqoZPt2VLATJW6g1VjfmKerwwLqIZ4n S9l1dwm0TD+tgwmVcakpd/I7dIxqUMvkxA/xijbYnw1AammKRkH1KHUCAwEAAQ=="
abmadmin.dlan.legacy.test. 3600  IN      CNAME   abmfe01.dlan.legacy.test.
EOF
INFO - Creating zone dlan.legacy.test
...snippet...
RECORD - 1021931729._dkimkey.dlan.legacy.test. 300 IN TXT "v=DKIM1;k=rsa;p=MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQCFpZEaLQAbzDDMkmDMZNzulKNI9QWcGOtD9SaMPwJ48xHRfTUxW1AIUgH/i1gFg0uM988hcNSyljkK81p0ASDGTmRBEwDZrHE+G96XOUhi4OZppteMswbbuDy3AIXQB/JG5ktFl0eYdAejkucOG0uIlvpeNhrSNn2wjASgYlqJBwIDAQAB"
ERROR - Object of type bytes is not JSON serializable
RECORD - 1021931729._domainkey.dlan.legacy.test. 300 IN TXT "v=DKIM1;k=rsa;p=MFwwDQYJKoZIhvcNAQEBBQADSwAwSAJBAKqoZPt2VLATJW6g1VjfmKerwwLqIZ4n S9l1dwm0TD+tgwmVcakpd/I7dIxqUMvkxA/xijbYnw1AammKRkH1KHUCAwEAAQ=="
ERROR - Object of type bytes is not JSON serializable
...snippet...
```

It was because of using the iterable variable `strings` which needed to iterate that, so `to_text()` function satisfied our requirement.

after patch:
```
$ cat <<EOF | ndcli import zone dlan.legacy.test
; <<>> DiG 9.8.2rc1-RedHat-9.8.2-0.10.rc1.el6_3.6 <<>> axfr dlan.legacy.test @anyins-ins-bs01.dlan.legacy.test
;; global options: +cmd
dlan.legacy.test.        3600    IN      SOA     ins01.internal.test. dnsadmin.company.com. 2005110840 600 180 604800 3600
dlan.legacy.test.        3600    IN      NS      ins01.internal.test.
dlan.legacy.test.        3600    IN      NS      ins02.internal.test.
1021931729._dkimkey.dlan.legacy.test. 300 IN TXT "v=DKIM1\;k=rsa\;p=MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQCFpZEaLQAbzDDMkmDMZNzulKNI9QWcGOtD9SaMPwJ48xHRfTUxW1AIUgH/i1gFg0uM988hcNSyljkK81p0ASDGTmRBEwDZrHE+G96XOUhi4OZppteMswbbuDy3AIXQB/JG5ktFl0eYdAejkucOG0uIlvpeNhrSNn2wjASgYlqJBwIDAQAB"
1021931729._domainkey.dlan.legacy.test. 300 IN TXT "v=DKIM1\;k=rsa\;p=MFwwDQYJKoZIhvcNAQEBBQADSwAwSAJBAKqoZPt2VLATJW6g1VjfmKerwwLqIZ4n S9l1dwm0TD+tgwmVcakpd/I7dIxqUMvkxA/xijbYnw1AammKRkH1KHUCAwEAAQ=="
abmadmin.dlan.legacy.test. 3600  IN      CNAME   abmfe01.dlan.legacy.test.
EOF
INFO - Creating zone dlan.legacy.test
...snippet...
RECORD - 1021931729._dkimkey.dlan.legacy.test. 300 IN TXT "v=DKIM1;k=rsa;p=MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQCFpZEaLQAbzDDMkmDMZNzulKNI9QWcGOtD9SaMPwJ48xHRfTUxW1AIUgH/i1gFg0uM988hcNSyljkK81p0ASDGTmRBEwDZrHE+G96XOUhi4OZppteMswbbuDy3AIXQB/JG5ktFl0eYdAejkucOG0uIlvpeNhrSNn2wjASgYlqJBwIDAQAB"
INFO - Creating RR 1021931729._dkimkey 300 TXT "v=DKIM1;k=rsa;p=MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQCFpZEaLQAbzDDMkmDMZNzulKNI9QWcGOtD9SaMPwJ48xHRfTUxW1AIUgH/i1gFg0uM988hcNSyljkK81p0ASDGTmRBEwDZrHE+G96XOUhi4OZppteMswbbuDy3AIXQB/JG5ktFl0eYdAejkucOG0uIlvpeNhrSNn2wjASgYlqJBwIDAQAB" in zone dlan.legacy.test
RECORD - 1021931729._domainkey.dlan.legacy.test. 300 IN TXT "v=DKIM1;k=rsa;p=MFwwDQYJKoZIhvcNAQEBBQADSwAwSAJBAKqoZPt2VLATJW6g1VjfmKerwwLqIZ4n S9l1dwm0TD+tgwmVcakpd/I7dIxqUMvkxA/xijbYnw1AammKRkH1KHUCAwEAAQ=="
INFO - Creating RR 1021931729._domainkey 300 TXT "v=DKIM1;k=rsa;p=MFwwDQYJKoZIhvcNAQEBBQADSwAwSAJBAKqoZPt2VLATJW6g1VjfmKerwwLqIZ4n S9l1dwm0TD+tgwmVcakpd/I7dIxqUMvkxA/xijbYnw1AammKRkH1KHUCAwEAAQ==" in zone dlan.legacy.test
RECORD - abmadmin.dlan.legacy.test. 3600 IN CNAME abmfe01.dlan.legacy.test.
INFO - Creating RR abmadmin CNAME abmfe01.dlan.legacy.test. in zone dlan.legacy.test
WARNING - abmfe01.dlan.legacy.test. does not exist.
```

and asked from ndcli:
```
$ ndcli list zone dlan.legacy.test       
record                zone             ttl  type  value
@                     dlan.legacy.test 3600 SOA   ins01.internal.test. dnsadmin.company.com. 2005110845 600 180 604800 3600
@                     dlan.legacy.test      NS    ins01.internal.test.
@                     dlan.legacy.test      NS    ins02.internal.test.
1021931729._dkimkey   dlan.legacy.test 300  TXT   "v=DKIM1;k=rsa;p=MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQCFpZEaLQAbzDDMkmDMZNzulKNI9QWcGOtD9SaMPwJ48xHRfTUxW1AIUgH/i1gFg0uM988hcNSyljkK81p0ASDGTmRBEwDZrHE+G96XOUhi4OZppteMswbbuDy3AIXQB/JG5ktFl0eYdAejkucOG0uIlvpeNhrSNn2wjASgYlqJBwIDAQAB"
1021931729._domainkey dlan.legacy.test 300  TXT   "v=DKIM1;k=rsa;p=MFwwDQYJKoZIhvcNAQEBBQADSwAwSAJBAKqoZPt2VLATJW6g1VjfmKerwwLqIZ4n S9l1dwm0TD+tgwmVcakpd/I7dIxqUMvkxA/xijbYnw1AammKRkH1KHUCAwEAAQ=="
abmadmin              dlan.legacy.test      CNAME abmfe01.dlan.legacy.test.
```